### PR TITLE
Handle cases like '{{a}'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-module.exports = function(a, b, str) {
+module.exports = balanced;
+function balanced(a, b, str) {
   var bal = 0;
   var m = {};
+  var ended = false;
 
   for (var i = 0; i < str.length; i++) {
     if (a == str.substr(i, a.length)) {
@@ -8,6 +10,7 @@ module.exports = function(a, b, str) {
       bal++;
     }
     else if (b == str.substr(i, b.length) && 'start' in m) {
+      ended = true;
       bal--;
       if (!bal) {
         m.end = i;
@@ -20,5 +23,16 @@ module.exports = function(a, b, str) {
       }
     }
   }
-};
 
+  // if we opened more than we closed, find the one we closed
+  if (bal && ended) {
+    var start = m.start + a.length;
+    m = balanced(a, b, str.substr(start));
+    if (m) {
+      m.start += start;
+      m.end += start;
+      m.pre = str.slice(0, start) + m.pre;
+    }
+    return m;
+  }
+}

--- a/test/balanced.js
+++ b/test/balanced.js
@@ -9,6 +9,20 @@ test('balanced', function(t) {
     body: 'in{nest}',
     post: 'post'
   });
+  t.deepEqual(balanced('{', '}', '{{{{{{{{{in}post'), {
+    start: 8,
+    end: 11,
+    pre: '{{{{{{{{',
+    body: 'in',
+    post: 'post'
+  });
+  t.deepEqual(balanced('{', '}', 'pre{body{in}post'), {
+    start: 8,
+    end: 11,
+    pre: 'pre{body',
+    body: 'in',
+    post: 'post'
+  });
   t.deepEqual(balanced('{', '}', 'pre}{in{nest}}post'), {
     start: 4,
     end: 13,


### PR DESCRIPTION
It was returning undefined, instead of finding the matched token.

Related to changes to make `brace-expansion` more bash-like.  Happy to make this an option or something if it breaks intended behavior.
