### PR TITLE
Regex in arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 module.exports = balanced;
 function balanced(a, b, str) {
-  var matchA = str.match(a);
-  var matchB = str.match(b);
+  if (a instanceof RegExp) {
+    var matchA = str.match(a);
+    a = matchA ? matchA[0] : '';
+  }
 
-  a = a instanceof RegExp && matchA ? matchA[0] : a;
-  b = b instanceof RegExp && matchB ? matchB[0] : b;
+  if (b instanceof RegExp) {
+    var matchB = str.match(b);
+    b = matchB ? matchB[0] : '';
+  }
 
   var bal = 0;
   var m = {};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = balanced;
 function balanced(a, b, str) {
-  matchA = str.match(a)
-  matchB = str.match(b)
+  var matchA = str.match(a);
+  var matchB = str.match(b);
 
   a = a instanceof RegExp && matchA ? matchA[0] : a;
   b = b instanceof RegExp && matchB ? matchB[0] : b;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = balanced;
 function balanced(a, b, str) {
-  a = str.match(a)[0];
-  b = str.match(b)[0];
+  a = a instanceof RegExp ? str.match(a)[0] : a;
+  b = b instanceof RegExp ? str.match(b)[0] : b;
 
   var bal = 0;
   var m = {};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 module.exports = balanced;
 function balanced(a, b, str) {
+  var a = str.match(a)[0];
+  var b = str.match(b)[0];
+
   var bal = 0;
   var m = {};
   var ended = false;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = balanced;
 function balanced(a, b, str) {
-  var a = str.match(a)[0];
-  var b = str.match(b)[0];
+  a = str.match(a)[0];
+  b = str.match(b)[0];
 
   var bal = 0;
   var m = {};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 module.exports = balanced;
 function balanced(a, b, str) {
-  a = a instanceof RegExp ? str.match(a)[0] : a;
-  b = b instanceof RegExp ? str.match(b)[0] : b;
+  matchA = str.match(a)
+  matchB = str.match(b)
+
+  a = a instanceof RegExp && matchA ? matchA[0] : a;
+  b = b instanceof RegExp && matchB ? matchB[0] : b;
 
   var bal = 0;
   var m = {};

--- a/test/balanced.js
+++ b/test/balanced.js
@@ -2,6 +2,13 @@ var test = require('tape');
 var balanced = require('..');
 
 test('balanced', function(t) {
+  t.deepEqual(balanced(/\s+\{\s+/, /\s+\}\s+/, 'pre  {   in{nest}   }  post'), {
+    start: 3,
+    end: 12,
+    pre: 'pre',
+    body: 'in{nest}',
+    post: 'post'
+  });
   t.deepEqual(balanced('{', '}', 'pre{in{nest}}post'), {
     start: 3,
     end: 12,

--- a/test/balanced.js
+++ b/test/balanced.js
@@ -2,6 +2,7 @@ var test = require('tape');
 var balanced = require('..');
 
 test('balanced', function(t) {
+  t.notOk(balanced(/\{/, /\}/, 'nope'), 'should be notOk');
   t.deepEqual(balanced(/\s+\{\s+/, /\s+\}\s+/, 'pre  {   in{nest}   }  post'), {
     start: 3,
     end: 17,

--- a/test/balanced.js
+++ b/test/balanced.js
@@ -4,7 +4,7 @@ var balanced = require('..');
 test('balanced', function(t) {
   t.deepEqual(balanced(/\s+\{\s+/, /\s+\}\s+/, 'pre  {   in{nest}   }  post'), {
     start: 3,
-    end: 12,
+    end: 17,
     pre: 'pre',
     body: 'in{nest}',
     post: 'post'


### PR DESCRIPTION
Useful when you have a repeating or an unknown amount of characters in `a` or `b` and don't want them in the result.

Example
```scss
string = 'call   (   10   )   ';
```

Solution
```javascript
console.log(balance(/\s+\(\s+/, /\s+\)\s+/, string);
```

Returns
```
{ start: 4, end: 13, pre: 'call', body: '10', post: '' }
```