### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test
 .travis.yml
 Makefile
 example.js
+.github


### PR DESCRIPTION
.github should remain private while publishing NPM package

Because I Want To Make It Clear That It Is An Unnecessary Folder

(Every Module Builder Usually keeps the .github folder private when publishing to NPM)

Translated by Google Translate :(