### PR TITLE
package.json: Switch from "main" to "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/juliangruber/balanced-match.git"
   },
   "homepage": "https://github.com/juliangruber/balanced-match",
-  "main": "index.js",
+  "exports": "./index.js",
   "type": "module",
   "scripts": {
     "test": "standard --fix && node--test test/test.js",


### PR DESCRIPTION
This allows to actually do `import balanced from 'balanced-match'`

While currently you need to do `import balanced from 'balanced-match/index.js'`

See: <https://nodejs.org/api/packages.html>
